### PR TITLE
Remove username from the logout button

### DIFF
--- a/templates/common_header.html
+++ b/templates/common_header.html
@@ -57,7 +57,7 @@
 					</button>
 				</form>
 				<form class="header_form" action="/logout" method="POST">
-  					<button type="submit" class="button">Logout {{username}}</button>
+					<button type="submit" class="button">Logout</button>
 				</form>
 				{{/if}}
 			</div>


### PR DESCRIPTION
It's not really that useful in general, it takes unnecessary
space, and it makes it harder to render well in narrower screens.