### PR TITLE
Simplify theme handling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -33,7 +33,8 @@
 	margin: 1em;
 }
 
-#top_div {
+/* Defaults for the default, light theme */
+body {
 	--background-color:#fff;
 	--color:#000;
 	--color-a:#339;
@@ -42,13 +43,14 @@
 	--color-shadow: #aaa;
 	--dark-visible-button: none;
 	--light-visible-button: inherit;
+
 	--add-pin-visible: none;
 	--header-height: 3.8em;
 }
 
-input#theme_switch:checked ~ #top_div{
-	--color:#f7f7f7;
+body.dark-theme {
 	--background-color: #222;
+	--color:#f7f7f7;
 	--color-a:#b7b7ff;
 	--color-a-visited:#d7d7d7;
 	--color-light-shadow: #171717;
@@ -107,12 +109,9 @@ input, textarea {
 	border-radius: 2px;
 }
 
-.contents {
-	min-height:100vh;
+body {
 	color: var(--color);
-	height: auto;
-	padding-bottom: 90px;
-	background-color:var(--background-color);
+	background-color: var(--background-color);
 }
 
 .markdown_content {

--- a/templates/common_header.html
+++ b/templates/common_header.html
@@ -23,7 +23,7 @@
 			}
 		</script>
 	</head>
-	<body>
+	<body class="{{theme}}-theme">
 		<!-- Invisible checkboxes to toggle features in the website-->
 		<input type="checkbox" id="theme_switch" style="display:none"/>
 		<input type="checkbox" id="add_pin_switch" style="display:none"/>


### PR DESCRIPTION
Instead of relying on a hack to choose the theme in CSS, set it
explicitly from the backend in a variable that will be read by the
templates.

The templates then can set a special CSS class name in the body
element, and all the CSS will be correctly applied. Also, remove a
now-unnecessary hack to make the dark theme cover the whole page.